### PR TITLE
Replace local images with remote placeholders

### DIFF
--- a/frontend/components/About.js
+++ b/frontend/components/About.js
@@ -1,0 +1,31 @@
+// Component: About
+import styles from '@/styles/About.module.css'
+
+const amenities = [
+  { icon: 'fa-bed', label: 'Комфортни стаи' },
+  { icon: 'fa-wifi', label: 'Wi-Fi' },
+  { icon: 'fa-utensils', label: 'Кухня' },
+  { icon: 'fa-tree', label: 'Градина' },
+  { icon: 'fa-car', label: 'Паркинг' },
+  { icon: 'fa-swimming-pool', label: 'Басейн' },
+  { icon: 'fa-fire', label: 'Барбекю' },
+  { icon: 'fa-child', label: 'Детски кът' },
+  { icon: 'fa-dog', label: 'Домашни любимци' },
+]
+
+export default function About() {
+  return (
+    <section id="за-нас" className={styles.about}>
+      <h2>За нас</h2>
+      <p>Предлагаме две уютни къщи сред величествената природа на Априлци.</p>
+      <div className={styles.grid}>
+        {amenities.map(({icon, label}) => (
+          <div key={label} className={styles.item}>
+            <i className={`fa-solid ${icon}`}></i>
+            <span>{label}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/frontend/components/Contact.js
+++ b/frontend/components/Contact.js
@@ -1,0 +1,35 @@
+// Component: Contact
+import { useState } from 'react'
+import styles from '@/styles/Contact.module.css'
+
+export default function Contact() {
+  const [form, setForm] = useState({ name: '', email: '', phone: '', message: '' })
+
+  const handleChange = e => {
+    setForm({ ...form, [e.target.name]: e.target.value })
+  }
+
+  const handleSubmit = e => {
+    e.preventDefault()
+    alert('Submitted!')
+  }
+
+  return (
+    <section id="контакт" className={styles.contact}>
+      <div className={styles.formWrap}>
+        <form onSubmit={handleSubmit} className={styles.form}>
+          <input name="name" placeholder="Име" value={form.name} onChange={handleChange} required />
+          <input type="email" name="email" placeholder="Email" value={form.email} onChange={handleChange} required />
+          <input name="phone" placeholder="Телефон" value={form.phone} onChange={handleChange} />
+          <textarea name="message" placeholder="Съобщение" value={form.message} onChange={handleChange} />
+          <button type="submit">Изпрати</button>
+        </form>
+      </div>
+      <div className={styles.info}>
+        <p><a href="tel:+3590000000">+359 000 0000</a></p>
+        <p><a href="mailto:info@example.com">info@example.com</a></p>
+        <p>Свържете се с нас за повече информация!</p>
+      </div>
+    </section>
+  )
+}

--- a/frontend/components/Footer.js
+++ b/frontend/components/Footer.js
@@ -1,0 +1,10 @@
+// Component: Footer
+import styles from '@/styles/Footer.module.css'
+
+export default function Footer() {
+  return (
+    <footer className={styles.footer}>
+      © 2025 Gracia House. Всички права запазени.
+    </footer>
+  )
+}

--- a/frontend/components/Gallery.js
+++ b/frontend/components/Gallery.js
@@ -1,0 +1,34 @@
+// Component: Gallery
+import { useState } from 'react'
+import styles from '@/styles/Gallery.module.css'
+
+const images = Array.from({ length: 9 }).map((_, i) =>
+  `https://via.placeholder.com/600x400?text=Gallery+${i + 1}`
+)
+
+export default function Gallery() {
+  const [current, setCurrent] = useState(null)
+
+  const close = () => setCurrent(null)
+  const prev = () => setCurrent((current - 1 + images.length) % images.length)
+  const next = () => setCurrent((current + 1) % images.length)
+
+  return (
+    <section id="галерия" className={styles.gallery}>
+      <h2>Галерия</h2>
+      <div className={styles.grid}>
+        {images.map((src, i) => (
+          <img key={i} src={src} onClick={() => setCurrent(i)} alt="galeria" />
+        ))}
+      </div>
+      {current !== null && (
+        <div className={styles.lightbox} onClick={close}>
+          <button className={styles.prev} onClick={e => {e.stopPropagation();prev()}}>&lt;</button>
+          <img src={images[current]} alt="big" />
+          <button className={styles.next} onClick={e => {e.stopPropagation();next()}}>&gt;</button>
+          <button className={styles.close} onClick={close}>×</button>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/frontend/components/Header.js
+++ b/frontend/components/Header.js
@@ -1,0 +1,35 @@
+// Component: Header
+import { useEffect, useState } from 'react'
+import styles from '@/styles/Header.module.css'
+
+export default function Header() {
+  const [scrolled, setScrolled] = useState(false)
+
+  useEffect(() => {
+    const onScroll = () => {
+      setScrolled(window.scrollY > 50)
+    }
+    window.addEventListener('scroll', onScroll)
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [])
+
+  const handleClick = (e, id) => {
+    e.preventDefault()
+    document.querySelector(id)?.scrollIntoView({ behavior: 'smooth' })
+  }
+
+  return (
+    <header className={`${styles.header} ${scrolled ? styles.scrolled : ''}`}> 
+      <nav className={styles.nav}>
+        <a href="#" className={styles.logo}>Gracia House</a>
+        <div className={styles.links}>
+          <a href="#" onClick={e => handleClick(e, '#начало')}>Начало</a>
+          <a href="#" onClick={e => handleClick(e, '#за-нас')}>За нас</a>
+          <a href="#" onClick={e => handleClick(e, '#галерия')}>Галерия</a>
+          <a href="#" onClick={e => handleClick(e, '#ревюта')}>Ревюта</a>
+          <a href="#" className={styles.button} onClick={e => handleClick(e, '#контакт')}>Контакт</a>
+        </div>
+      </nav>
+    </header>
+  )
+}

--- a/frontend/components/Hero.js
+++ b/frontend/components/Hero.js
@@ -1,0 +1,35 @@
+// Component: Hero
+import { useEffect, useState } from 'react'
+import styles from '@/styles/Hero.module.css'
+
+const images = [
+  'https://via.placeholder.com/1200x800?text=Hero+1',
+  'https://via.placeholder.com/1200x800?text=Hero+2',
+  'https://via.placeholder.com/1200x800?text=Hero+3',
+  'https://via.placeholder.com/1200x800?text=Hero+4'
+]
+
+export default function Hero() {
+  const [index, setIndex] = useState(0)
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setIndex(i => (i + 1) % images.length)
+    }, 4000)
+    return () => clearInterval(id)
+  }, [])
+
+  const handleScroll = () => {
+    document.querySelector('#за-нас')?.scrollIntoView({ behavior: 'smooth' })
+  }
+
+  return (
+    <section id="начало" className={styles.hero} style={{backgroundImage:`url(${images[index]})`}}>
+      <div className={styles.overlay}>
+        <h1>Gracia House</h1>
+        <h2>Вашият уют в сърцето на природата</h2>
+        <button onClick={handleScroll}>Научи повече</button>
+      </div>
+    </section>
+  )
+}

--- a/frontend/components/Location.js
+++ b/frontend/components/Location.js
@@ -1,0 +1,18 @@
+// Component: Location
+import styles from '@/styles/Location.module.css'
+
+export default function Location() {
+  const openMap = () => {
+    window.open('https://maps.google.com/?q=Apriltsi,Bulgaria', '_blank')
+  }
+
+  return (
+    <section className={styles.location}>
+      <h2>Локация</h2>
+      <iframe
+        src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2907.926995412542!2d24.92300731545017!3d42.819525379159624!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0:0x0!2zNDLCsDQ5JzA5LjMiTiAyNMKwNTUnMjAuNCJF!5e0!3m2!1sen!2sbg!4v1715281213123"
+        width="600" height="450" allowFullScreen="" loading="lazy" referrerPolicy="no-referrer-when-downgrade"></iframe>
+      <button onClick={openMap}>Отвори в Google Maps</button>
+    </section>
+  )
+}

--- a/frontend/components/Reviews.js
+++ b/frontend/components/Reviews.js
@@ -1,0 +1,25 @@
+// Component: Reviews
+import styles from '@/styles/Reviews.module.css'
+
+const data = [
+  { text: 'Страхотно място за семейна почивка.', name: 'Иван', date: 'Юли 2025' },
+  { text: 'Невероятна гледка и уютни стаи.', name: 'Мария', date: 'Юни 2025' },
+  { text: 'Ще посетим отново!', name: 'Георги', date: 'Май 2025' }
+]
+
+export default function Reviews() {
+  return (
+    <section id="ревюта" className={styles.reviews}>
+      <h2>Ревюта</h2>
+      <div className={styles.grid}>
+        {data.map((r, i) => (
+          <div key={i} className={styles.card}>
+            <div className={styles.stars}>★★★★★</div>
+            <p>{r.text}</p>
+            <span>{r.name}, {r.date}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -1,0 +1,21 @@
+// Component: Custom App
+import '@/styles/globals.css'
+import { Playfair_Display, Open_Sans } from 'next/font/google'
+import Head from 'next/head'
+
+const playfair = Playfair_Display({ subsets: ['latin'], variable: '--font-playfair', weight: ['400','700'] })
+const openSans = Open_Sans({ subsets: ['latin'], variable: '--font-open-sans', weight: ['400','700'] })
+
+export default function App({ Component, pageProps }) {
+  return (
+    <div className={`${playfair.variable} ${openSans.variable}`}>
+      <Head>
+        <link
+          rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
+        />
+      </Head>
+      <Component {...pageProps} />
+    </div>
+  )
+}

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,0 +1,24 @@
+// Page: Home
+import Header from '@/components/Header'
+import Hero from '@/components/Hero'
+import About from '@/components/About'
+import Gallery from '@/components/Gallery'
+import Location from '@/components/Location'
+import Reviews from '@/components/Reviews'
+import Contact from '@/components/Contact'
+import Footer from '@/components/Footer'
+
+export default function Home() {
+  return (
+    <>
+      <Header />
+      <Hero />
+      <About />
+      <Gallery />
+      <Location />
+      <Reviews />
+      <Contact />
+      <Footer />
+    </>
+  )
+}

--- a/frontend/styles/About.module.css
+++ b/frontend/styles/About.module.css
@@ -1,0 +1,36 @@
+.about {
+  padding: 2rem 1rem;
+  text-align: center;
+}
+
+.about h2 {
+  font-family: 'Playfair Display', serif;
+  margin-bottom: 1rem;
+  font-size: 1.5rem;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-size: 0.9rem;
+}
+
+.item i {
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+@media (min-width: 768px) {
+  .grid { grid-template-columns: repeat(3, 1fr); }
+}
+@media (min-width: 1024px) {
+  .grid { grid-template-columns: repeat(3, 1fr); }
+}

--- a/frontend/styles/Contact.module.css
+++ b/frontend/styles/Contact.module.css
@@ -1,0 +1,39 @@
+.contact {
+  padding: 2rem 1rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.formWrap {
+  flex: 1;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.form input,
+.form textarea {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.form button {
+  padding: 0.5rem 1rem;
+  background: var(--accent);
+  color: white;
+  border: none;
+  border-radius: 4px;
+}
+
+.info {
+  text-align: center;
+}
+
+@media (min-width: 768px) {
+  .contact { grid-template-columns: 1fr 1fr; }
+  .info { display: flex; flex-direction: column; justify-content: center; }
+}

--- a/frontend/styles/Footer.module.css
+++ b/frontend/styles/Footer.module.css
@@ -1,0 +1,6 @@
+.footer {
+  text-align: center;
+  padding: 1rem;
+  background: #333;
+  color: #fff;
+}

--- a/frontend/styles/Gallery.module.css
+++ b/frontend/styles/Gallery.module.css
@@ -1,0 +1,54 @@
+.gallery {
+  padding: 2rem 1rem;
+  text-align: center;
+}
+
+.gallery h2 {
+  font-family: 'Playfair Display', serif;
+  margin-bottom: 1rem;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(1, 1fr);
+  gap: 0.5rem;
+}
+
+.grid img {
+  width: 100%;
+  cursor: pointer;
+}
+
+@media (min-width: 600px) {
+  .grid { grid-template-columns: repeat(2, 1fr); }
+}
+@media (min-width: 1024px) {
+  .grid { grid-template-columns: repeat(4, 1fr); }
+}
+
+.lightbox {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0,0,0,0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+.lightbox img {
+  max-width: 90%;
+  max-height: 90%;
+}
+.prev, .next, .close {
+  position: absolute;
+  background: transparent;
+  color: white;
+  border: none;
+  font-size: 2rem;
+}
+.prev { left: 2%; }
+.next { right: 2%; }
+.close { top: 2%; right: 2%; font-size: 2.5rem; }

--- a/frontend/styles/Header.module.css
+++ b/frontend/styles/Header.module.css
@@ -1,0 +1,36 @@
+.header {
+  position: sticky;
+  top: 0;
+  width: 100%;
+  z-index: 50;
+  transition: background 0.3s;
+}
+
+.scrolled {
+  background: rgba(245, 240, 232, 0.9);
+  backdrop-filter: blur(4px);
+}
+
+.nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+}
+
+.logo {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+.links a {
+  margin-left: 1rem;
+}
+
+.button {
+  padding: 0.5rem 1rem;
+  background: var(--accent);
+  color: white;
+  border-radius: 4px;
+}

--- a/frontend/styles/Hero.module.css
+++ b/frontend/styles/Hero.module.css
@@ -1,0 +1,42 @@
+.hero {
+  height: 100vh;
+  background-size: cover;
+  background-position: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  animation: fade 1s ease-in;
+}
+
+@keyframes fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.overlay {
+  text-align: center;
+  color: #fff;
+  background: rgba(0,0,0,0.3);
+  padding: 2rem;
+}
+
+.overlay h1 {
+  font-family: 'Playfair Display', serif;
+  margin: 0;
+  font-size: 2rem;
+}
+
+.overlay h2 {
+  margin-top: .5rem;
+  font-size: 1rem;
+}
+
+.overlay button {
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  background: var(--accent);
+  color: white;
+  border: none;
+  border-radius: 4px;
+}

--- a/frontend/styles/Location.module.css
+++ b/frontend/styles/Location.module.css
@@ -1,0 +1,24 @@
+.location {
+  padding: 2rem 1rem;
+  text-align: center;
+}
+
+.location h2 {
+  font-family: 'Playfair Display', serif;
+  margin-bottom: 1rem;
+}
+
+iframe {
+  width: 100%;
+  border: 0;
+  height: 300px;
+}
+
+button {
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  background: var(--accent);
+  color: white;
+  border: none;
+  border-radius: 4px;
+}

--- a/frontend/styles/Reviews.module.css
+++ b/frontend/styles/Reviews.module.css
@@ -1,0 +1,29 @@
+.reviews {
+  padding: 2rem 1rem;
+  text-align: center;
+}
+
+.reviews h2 {
+  font-family: 'Playfair Display', serif;
+  margin-bottom: 1rem;
+}
+
+.grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.card {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 4px;
+}
+
+.stars {
+  color: gold;
+  margin-bottom: 0.5rem;
+}
+
+@media (min-width: 600px) {
+  .grid { grid-template-columns: repeat(3, 1fr); }
+}

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,0 +1,25 @@
+:root {
+  --text: #3D3B3B;
+  --bg:   #F5F0E8;
+  --accent: #A89E8A;
+  font-family: 'Open Sans', sans-serif;
+}
+
+body {
+  margin: 0;
+  color: var(--text);
+  background: var(--bg);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Playfair Display', serif;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -18,9 +18,9 @@
         "name": "next"
       }
     ],
-    "baseUrl": ".", // This is critical to make aliases work
+    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## Summary
- remove binary image assets
- load FontAwesome CDN in custom App component
- use font-awesome classes in About section
- swap local hero and gallery images for remote placeholders
- tweak global and about styles for new icons

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a606be7cc8330b6490bca286461cc