### PR TITLE
Add components to app homepage

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,10 +1,25 @@
 import Hello from "./components/hello";
+import Header from "@/src/app/components/Header";
+import Hero from "@/src/app/components/Hero";
+import About from "@/src/app/components/About";
+import Gallery from "@/src/app/components/Gallery";
+import Location from "@/src/app/components/Location";
+import Reviews from "@/src/app/components/Reviews";
+import Contact from "@/src/app/components/Contact";
+import Footer from "@/src/app/components/Footer";
 
 export default function Home() {
   return (
-    <div>
-      <Hello></Hello>
-      <h1 className="text-3xl">Wlcome to next.js</h1>
-    </div>
+    <>
+      <Header />
+      <Hero />
+      <About />
+      <Gallery />
+      <Location />
+      <Reviews />
+      <Contact />
+      <Hello />
+      <Footer />
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- import site components on the `/src/app` home page
- assemble them in order so the home page matches the rest of the site

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a7b6e787c8330a5d7061fcf6985c1